### PR TITLE
Add comment parsing to the simulator

### DIFF
--- a/uppyyl_simulator/backend/ast/parsers/uppaal_xml_model_parser.py
+++ b/uppyyl_simulator/backend/ast/parsers/uppaal_xml_model_parser.py
@@ -166,6 +166,8 @@ def uppaal_xml_to_dict(system_xml_str):
             edge["sync_label"] = None
             edge["select"] = None
             edge["select_label"] = None
+            edge["comment"] = None
+            edge["comment_label"] = None
             label_elements = edge_element.findall("label")
             for label_element in label_elements:
                 label = OrderedDict()
@@ -187,6 +189,9 @@ def uppaal_xml_to_dict(system_xml_str):
                 elif label_element.attrib["kind"] == "select":
                     edge["select"] = label_element.text
                     edge["select_label"] = label
+                elif label_element.attrib["kind"] == "comment":
+                    edge["comment"] = label_element.text
+                    edge["comment_label"] = label
 
             # Parse edge nails
             edge["nails"] = []
@@ -366,6 +371,12 @@ def uppaal_dict_to_system(system_data):
                 edge.new_select(edge_data["select"])
             if edge_data["select_label"]:
                 edge.view["select_label"] = edge_data["select_label"].copy()
+
+            # Add comments
+            if edge_data["comment"]:
+                edge.add_comment(edge_data["comment"])
+            if edge_data["comment_label"]:
+                edge.view["comment_label"] = edge_data["comment_label"].copy()
 
             edge.view["nails"] = OrderedDict()
             for nail in edge_data["nails"]:

--- a/uppyyl_simulator/backend/ast/parsers/uppaal_xml_model_parser.py
+++ b/uppyyl_simulator/backend/ast/parsers/uppaal_xml_model_parser.py
@@ -166,8 +166,8 @@ def uppaal_xml_to_dict(system_xml_str):
             edge["sync_label"] = None
             edge["select"] = None
             edge["select_label"] = None
-            edge["comment"] = None
-            edge["comment_label"] = None
+            edge["comments"] = None
+            edge["comments_label"] = None
             label_elements = edge_element.findall("label")
             for label_element in label_elements:
                 label = OrderedDict()
@@ -189,9 +189,9 @@ def uppaal_xml_to_dict(system_xml_str):
                 elif label_element.attrib["kind"] == "select":
                     edge["select"] = label_element.text
                     edge["select_label"] = label
-                elif label_element.attrib["kind"] == "comment":
-                    edge["comment"] = label_element.text
-                    edge["comment_label"] = label
+                elif label_element.attrib["kind"] == "comments":
+                    edge["comments"] = label_element.text
+                    edge["comments_label"] = label
 
             # Parse edge nails
             edge["nails"] = []
@@ -373,10 +373,10 @@ def uppaal_dict_to_system(system_data):
                 edge.view["select_label"] = edge_data["select_label"].copy()
 
             # Add comments
-            if edge_data["comment"]:
-                edge.add_comment(edge_data["comment"])
-            if edge_data["comment_label"]:
-                edge.view["comment_label"] = edge_data["comment_label"].copy()
+            if edge_data["comments"]:
+                edge.add_comment(edge_data["comments"])
+            if edge_data["comments_label"]:
+                edge.view["comments_label"] = edge_data["comments_label"].copy()
 
             edge.view["nails"] = OrderedDict()
             for nail in edge_data["nails"]:

--- a/uppyyl_simulator/backend/models/ta/ta.py
+++ b/uppyyl_simulator/backend/models/ta/ta.py
@@ -355,6 +355,7 @@ class Edge(basic_automaton.Edge):
         self.resets = []
         self.sync = None
         self.selects = []
+        self.comment = None
 
         self.view = {"nails": OrderedDict()}
 
@@ -364,6 +365,7 @@ class Edge(basic_automaton.Edge):
         self.view["update_label"] = {"pos": {"x": center["x"], "y": center["y"]}, "id": unique_id("label")}
         self.view["sync_label"] = {"pos": {"x": center["x"], "y": center["y"] + 20}, "id": unique_id("label")}
         self.view["select_label"] = {"pos": {"x": center["x"], "y": center["y"] - 40}, "id": unique_id("label")}
+        self.view["comment_label"] = {"pos": {"x": center["x"], "y": center["y"] + 40}, "id": unique_id("label")}
 
     def add_nail(self, pos):
         """Adds a fixed point (nail) to the graphical representation of the edge.
@@ -501,6 +503,15 @@ class Edge(basic_automaton.Edge):
         rst = Reset(rst_data, self.parent)
         self.add_reset(rst)
         return rst
+
+    def add_comment(self, comment):
+        """Adds a comment to the edge
+
+        Args:
+            comment: Comment on edge.
+        """
+
+        self.comment = comment
 
     def set_sync(self, sync):
         """Sets the synchronization label.


### PR DESCRIPTION
Comments in uppaal models xml file are now parsed and stored in Edge as a string property "comment". This allows to access the comments in the simulator, which is convenient when indexing edges to match them with edges in a trace in iterative TarTar