### PR TITLE
Parse the id of transitions if it is set in the model's xml file

### DIFF
--- a/uppyyl_simulator/backend/ast/parsers/uppaal_xml_model_parser.py
+++ b/uppyyl_simulator/backend/ast/parsers/uppaal_xml_model_parser.py
@@ -145,7 +145,8 @@ def uppaal_xml_to_dict(system_xml_str):
         edge_elements = template_element.findall("transition")
         for edge_element in edge_elements:
             edge = OrderedDict()
-            edge["id"] = unique_id("edge")
+            #edge["id"] = unique_id("edge")
+            edge["id"] = edge_element.get("id") if edge_element.get("id") is not None else unique_id("edge")
 
             # Parse edge source location
             edge_source_element = edge_element.find("source")


### PR DESCRIPTION
When transitions are parsed by a simulator, they are assigned an generated id. In order to efficiently find transition in xml file I suggest we make ids that are present in xml be parsed by a simulator.